### PR TITLE
Fix 404 errors for project images on projects page

### DIFF
--- a/public/projects.html
+++ b/public/projects.html
@@ -63,7 +63,7 @@
 
         <div class="eng-card project-card stagger-1 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/pipro.jpg" alt="2D Contour Detection" class="card-img">
+            <img src="assets/images/pipro.jpg" alt="2D Contour Detection" class="card-img">
           </div>
           <div class="card-body">
             <h3>2D Contour Detection &amp; 3D Depth Mapping System</h3>
@@ -80,7 +80,7 @@
 
         <div class="eng-card project-card stagger-2 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/robot.png" alt="Autonomous Robot" class="card-img">
+            <img src="assets/images/robot.png" alt="Autonomous Robot" class="card-img">
           </div>
           <div class="card-body">
             <h3>Internal Logistics Autonomous Robot</h3>
@@ -97,7 +97,7 @@
 
         <div class="eng-card project-card stagger-3 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/sha.png" alt="Structural Health Monitoring" class="card-img">
+            <img src="assets/images/sha.png" alt="Structural Health Monitoring" class="card-img">
           </div>
           <div class="card-body">
             <h3>AI-Based Structural Health Monitoring System</h3>
@@ -114,7 +114,7 @@
 
         <div class="eng-card project-card stagger-4 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project5.jpg" alt="GPS Delivery Robot" class="card-img">
+            <img src="assets/images/project5.jpg" alt="GPS Delivery Robot" class="card-img">
           </div>
           <div class="card-body">
             <h3>Autonomous GPS-Based Delivery Robot</h3>
@@ -131,7 +131,7 @@
 
         <div class="eng-card project-card stagger-5 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project1.jpg" alt="Robotic Arm" class="card-img">
+            <img src="assets/images/project1.jpg" alt="Robotic Arm" class="card-img">
           </div>
           <div class="card-body">
             <h3>Four-Axis Robotic Arm with Precision Control</h3>
@@ -148,7 +148,7 @@
 
         <div class="eng-card project-card stagger-6 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project8.jpg" alt="Emergency Communication" class="card-img">
+            <img src="assets/images/project8.jpg" alt="Emergency Communication" class="card-img">
           </div>
           <div class="card-body">
             <h3>Emergency Communication &amp; Alert System</h3>
@@ -165,7 +165,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project6.jpg" alt="Wireless Rover" class="card-img">
+            <img src="assets/images/project6.jpg" alt="Wireless Rover" class="card-img">
           </div>
           <div class="card-body">
             <h3>Dual-Mode Wireless Rover</h3>
@@ -182,7 +182,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project7.jpg" alt="2-Wheel Bot" class="card-img">
+            <img src="assets/images/project7.jpg" alt="2-Wheel Bot" class="card-img">
           </div>
           <div class="card-body">
             <h3>Auto-Balance 2-Wheel Bot Using 3-Axis Gyroscope</h3>
@@ -210,7 +210,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/moon.png" alt="Moon Phase Detector" class="card-img">
+            <img src="assets/images/moon.png" alt="Moon Phase Detector" class="card-img">
           </div>
           <div class="card-body">
             <h3>Moon Phase Detector Using Python and OpenCV</h3>
@@ -222,7 +222,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/leaf.png" alt="Leaf Disease Detection" class="card-img">
+            <img src="assets/images/leaf.png" alt="Leaf Disease Detection" class="card-img">
           </div>
           <div class="card-body">
             <h3>Leaf Disease Detection Using Python and OpenCV</h3>
@@ -234,7 +234,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/comm.png" alt="Network Communication" class="card-img">
+            <img src="assets/images/comm.png" alt="Network Communication" class="card-img">
           </div>
           <div class="card-body">
             <h3>Simulated Network Message Communication</h3>
@@ -246,7 +246,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/auction.png" alt="IPL Auction" class="card-img">
+            <img src="assets/images/auction.png" alt="IPL Auction" class="card-img">
           </div>
           <div class="card-body">
             <h3>IPL Auction System Using Python</h3>
@@ -258,7 +258,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/winp.png" alt="Cricket Predictor" class="card-img">
+            <img src="assets/images/winp.png" alt="Cricket Predictor" class="card-img">
           </div>
           <div class="card-body">
             <h3>Cricket Match Win Predictor Using Java</h3>
@@ -270,7 +270,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/invt.png" alt="Inventory Management" class="card-img">
+            <img src="assets/images/invt.png" alt="Inventory Management" class="card-img">
           </div>
           <div class="card-body">
             <h3>Inventory Management System (Python + SQLite)</h3>
@@ -282,7 +282,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/lib.png" alt="Library Management" class="card-img">
+            <img src="assets/images/lib.png" alt="Library Management" class="card-img">
           </div>
           <div class="card-body">
             <h3>Library Management System (Python + MySQL)</h3>
@@ -294,7 +294,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/attend.png" alt="Attendance System" class="card-img">
+            <img src="assets/images/attend.png" alt="Attendance System" class="card-img">
           </div>
           <div class="card-body">
             <h3>QR Code Attendance Management System</h3>
@@ -306,7 +306,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/audio.png" alt="Audio Player" class="card-img">
+            <img src="assets/images/audio.png" alt="Audio Player" class="card-img">
           </div>
           <div class="card-body">
             <h3>Audio Player Using Python</h3>
@@ -318,7 +318,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/bank.png" alt="Bank Management" class="card-img">
+            <img src="assets/images/bank.png" alt="Bank Management" class="card-img">
           </div>
           <div class="card-body">
             <h3>Bank Management System (Python + MySQL)</h3>
@@ -330,7 +330,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/elec.png" alt="ElectroRookie Calculator" class="card-img">
+            <img src="assets/images/elec.png" alt="ElectroRookie Calculator" class="card-img">
           </div>
           <div class="card-body">
             <h3>ElectroRookie: Electronics Calculator</h3>
@@ -342,7 +342,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/it.png" alt="YouTube Website" class="card-img">
+            <img src="assets/images/it.png" alt="YouTube Website" class="card-img">
           </div>
           <div class="card-body">
             <h3>Website for YouTube Channel</h3>
@@ -354,7 +354,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/ki.png" alt="Kreotix Website" class="card-img">
+            <img src="assets/images/ki.png" alt="Kreotix Website" class="card-img">
           </div>
           <div class="card-body">
             <h3>Website for Kreotix Innovations</h3>

--- a/src/projects.html
+++ b/src/projects.html
@@ -63,7 +63,7 @@
 
         <div class="eng-card project-card stagger-1 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/pipro.jpg" alt="2D Contour Detection" class="card-img">
+            <img src="assets/images/pipro.jpg" alt="2D Contour Detection" class="card-img">
           </div>
           <div class="card-body">
             <h3>2D Contour Detection &amp; 3D Depth Mapping System</h3>
@@ -80,7 +80,7 @@
 
         <div class="eng-card project-card stagger-2 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/robot.png" alt="Autonomous Robot" class="card-img">
+            <img src="assets/images/robot.png" alt="Autonomous Robot" class="card-img">
           </div>
           <div class="card-body">
             <h3>Internal Logistics Autonomous Robot</h3>
@@ -97,7 +97,7 @@
 
         <div class="eng-card project-card stagger-3 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/sha.png" alt="Structural Health Monitoring" class="card-img">
+            <img src="assets/images/sha.png" alt="Structural Health Monitoring" class="card-img">
           </div>
           <div class="card-body">
             <h3>AI-Based Structural Health Monitoring System</h3>
@@ -114,7 +114,7 @@
 
         <div class="eng-card project-card stagger-4 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project5.jpg" alt="GPS Delivery Robot" class="card-img">
+            <img src="assets/images/project5.jpg" alt="GPS Delivery Robot" class="card-img">
           </div>
           <div class="card-body">
             <h3>Autonomous GPS-Based Delivery Robot</h3>
@@ -131,7 +131,7 @@
 
         <div class="eng-card project-card stagger-5 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project1.jpg" alt="Robotic Arm" class="card-img">
+            <img src="assets/images/project1.jpg" alt="Robotic Arm" class="card-img">
           </div>
           <div class="card-body">
             <h3>Four-Axis Robotic Arm with Precision Control</h3>
@@ -148,7 +148,7 @@
 
         <div class="eng-card project-card stagger-6 reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project8.jpg" alt="Emergency Communication" class="card-img">
+            <img src="assets/images/project8.jpg" alt="Emergency Communication" class="card-img">
           </div>
           <div class="card-body">
             <h3>Emergency Communication &amp; Alert System</h3>
@@ -165,7 +165,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project6.jpg" alt="Wireless Rover" class="card-img">
+            <img src="assets/images/project6.jpg" alt="Wireless Rover" class="card-img">
           </div>
           <div class="card-body">
             <h3>Dual-Mode Wireless Rover</h3>
@@ -182,7 +182,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/project7.jpg" alt="2-Wheel Bot" class="card-img">
+            <img src="assets/images/project7.jpg" alt="2-Wheel Bot" class="card-img">
           </div>
           <div class="card-body">
             <h3>Auto-Balance 2-Wheel Bot Using 3-Axis Gyroscope</h3>
@@ -210,7 +210,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/moon.png" alt="Moon Phase Detector" class="card-img">
+            <img src="assets/images/moon.png" alt="Moon Phase Detector" class="card-img">
           </div>
           <div class="card-body">
             <h3>Moon Phase Detector Using Python and OpenCV</h3>
@@ -222,7 +222,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/leaf.png" alt="Leaf Disease Detection" class="card-img">
+            <img src="assets/images/leaf.png" alt="Leaf Disease Detection" class="card-img">
           </div>
           <div class="card-body">
             <h3>Leaf Disease Detection Using Python and OpenCV</h3>
@@ -234,7 +234,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/comm.png" alt="Network Communication" class="card-img">
+            <img src="assets/images/comm.png" alt="Network Communication" class="card-img">
           </div>
           <div class="card-body">
             <h3>Simulated Network Message Communication</h3>
@@ -246,7 +246,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/auction.png" alt="IPL Auction" class="card-img">
+            <img src="assets/images/auction.png" alt="IPL Auction" class="card-img">
           </div>
           <div class="card-body">
             <h3>IPL Auction System Using Python</h3>
@@ -258,7 +258,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/winp.png" alt="Cricket Predictor" class="card-img">
+            <img src="assets/images/winp.png" alt="Cricket Predictor" class="card-img">
           </div>
           <div class="card-body">
             <h3>Cricket Match Win Predictor Using Java</h3>
@@ -270,7 +270,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/invt.png" alt="Inventory Management" class="card-img">
+            <img src="assets/images/invt.png" alt="Inventory Management" class="card-img">
           </div>
           <div class="card-body">
             <h3>Inventory Management System (Python + SQLite)</h3>
@@ -282,7 +282,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/lib.png" alt="Library Management" class="card-img">
+            <img src="assets/images/lib.png" alt="Library Management" class="card-img">
           </div>
           <div class="card-body">
             <h3>Library Management System (Python + MySQL)</h3>
@@ -294,7 +294,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/attend.png" alt="Attendance System" class="card-img">
+            <img src="assets/images/attend.png" alt="Attendance System" class="card-img">
           </div>
           <div class="card-body">
             <h3>QR Code Attendance Management System</h3>
@@ -306,7 +306,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/audio.png" alt="Audio Player" class="card-img">
+            <img src="assets/images/audio.png" alt="Audio Player" class="card-img">
           </div>
           <div class="card-body">
             <h3>Audio Player Using Python</h3>
@@ -318,7 +318,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/bank.png" alt="Bank Management" class="card-img">
+            <img src="assets/images/bank.png" alt="Bank Management" class="card-img">
           </div>
           <div class="card-body">
             <h3>Bank Management System (Python + MySQL)</h3>
@@ -330,7 +330,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/elec.png" alt="ElectroRookie Calculator" class="card-img">
+            <img src="assets/images/elec.png" alt="ElectroRookie Calculator" class="card-img">
           </div>
           <div class="card-body">
             <h3>ElectroRookie: Electronics Calculator</h3>
@@ -342,7 +342,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/it.png" alt="YouTube Website" class="card-img">
+            <img src="assets/images/it.png" alt="YouTube Website" class="card-img">
           </div>
           <div class="card-body">
             <h3>Website for YouTube Channel</h3>
@@ -354,7 +354,7 @@
 
         <div class="eng-card project-card reveal">
           <div class="card-img-wrap">
-            <img src="../src/assets/images/ki.png" alt="Kreotix Website" class="card-img">
+            <img src="assets/images/ki.png" alt="Kreotix Website" class="card-img">
           </div>
           <div class="card-body">
             <h3>Website for Kreotix Innovations</h3>


### PR DESCRIPTION
### Motivation
- The projects pages were referencing images with `../src/assets/images/...` which caused 404s when served as static files because the built site serves images from `assets/images/` under `public/`.

### Description
- Updated image `src` attributes in `public/projects.html` to use `assets/images/...` instead of `../src/assets/images/...` so they resolve correctly in static hosting.
- Applied the same path corrections in `src/projects.html` to keep the source copy aligned with the deployed static page.
- The changes touch the project image tags across the projects grid so all previously broken project thumbnails now point at the correct served location.

### Testing
- Ran `npm run build` and the build completed successfully.
- Served the `public/` directory with `python3 -m http.server 4173` and loaded `/projects.html`, and the server logs showed the image requests returned HTTP 200.
- Verified with `rg` that there are no remaining occurrences of `../src/assets/images/` in the modified files and captured a Playwright screenshot of the rendered page to validate visuals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b67fe5e9188328b8897bb325787f43)